### PR TITLE
Reorder phrase and format API method as code

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -254,7 +254,7 @@ spec: DOM-Parsing; urlPrefix: https://w3c.github.io/DOM-Parsing/
   untrusted, whether third-party or their own, code.  Existing
   mechanisms (e.g.,
   CORS'sk<a><code>Access-Control-Allow-Origin</code></a> header and
-  the <a>postMessage()</a> <code>targetOrigin</code> argument) provide
+  the <code>targetOrigin</code> argument to <a><code>postMessage()</code></a>) provide
   a way for restricting which <a>origins</a> may access the shared data.
   But, once content has access to data it can usually disseminate it
   without restrictions.  While CSP can be used to confine code, i.e.,


### PR DESCRIPTION
The original ordering was a bit stilted, IMO. I think this improves the flow.
