### PR TITLE
Fix missing subject

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -432,7 +432,7 @@ spec: DOM-Parsing; urlPrefix: https://w3c.github.io/DOM-Parsing/
     <code><a>Label</a>("https://university.edu")._or("user2")</code>).
 
     The <a  href="#university-example-js">sub-origin isolation in
-    JavaScript</a> shows how this example can be implemented using the
+    JavaScript</a> example shows how this can be implemented using the
     COWL JavaScript APIs.
   </div>
 


### PR DESCRIPTION
The sentence needs a subject. I moved the existing instance of "example" so as to avoid awkward repetition.
