### PR TITLE
Remove ambiguity

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2000,7 +2000,7 @@ spec: WEBIDL2; urlPrefix: https://heycam.github.io/webidl/
           <var>json</var> as an argument.
 
           Note, that <code><a>send()</a></code>
-          throws an exception in step 4 if <var>obj</var> cannot be <a>serialized</a>.
+          throws an exception if <var>obj</var> cannot be <a>serialized</a>.
           User agents MUST ensure that all <a>protected object</a>s can be
           serialized at the time of creating <a interface>LabeledObject</a>s.
 


### PR DESCRIPTION
On first reading, this text led me to understand that step 4 of the algorithm _currently being explained_ would throw, which is not the case. Personally, I think a link to the `send` algorithm in question is sufficient.

If it's important to specify the step of `send` that will throw, I think it would be good to be more specific. Something like `Note that step 4 of the <code><a>send()</a></code> algorithm throws an exception...`
